### PR TITLE
bugfix: Move standardization of server names to a helper method

### DIFF
--- a/user/models.py
+++ b/user/models.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 from django.db import models
 from django.contrib.auth.models import User
 from encrypted_model_fields.fields import EncryptedCharField
@@ -8,6 +10,16 @@ class MastodonServer(models.Model):
     api_base_url = models.CharField(max_length=100)
     client_id = EncryptedCharField(max_length=500)
     client_secret = EncryptedCharField(max_length=500)
+
+
+    @staticmethod
+    def standardize_servername(server):
+        # Parse server url
+        if server.startswith("https://"):
+            server = "https://" + urlparse(server).netloc
+        else:
+            server = "https://" + server
+        return server
 
 
 class MastodonUser(models.Model):

--- a/user/views.py
+++ b/user/views.py
@@ -37,6 +37,7 @@ def login(request):
     # Server Name from coookie
     print(code)
     server = request.session.get('server')
+    server = MastodonServer.standardize_servername(server)
     print(server)
     mastoServer = MastodonServer.objects.get(api_base_url=server)
     api = Mastodon(
@@ -71,11 +72,7 @@ def login(request):
 def register(request):
     from urllib.parse import urlparse
     server = request.GET.get('server')
-    # Parse server url
-    if server.startswith("https://"):
-        server = "https://" + urlparse(server).netloc
-    else:
-        server = "https://" + server
+    server = MastodonServer.standardize_servername(server)
     mastoServer, created = MastodonServer.objects.get_or_create(
         api_base_url=server)
     request.session['server'] = server


### PR DESCRIPTION
On a dev setup, attempting to sign in with the mastodon instance I use was failing.  It was creating the MastodonServer item successfully, but not able to find it during login.  Adding this simple extractor fixed that for me.